### PR TITLE
[CHORE] - Use util to determaine API url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@codesandbox/utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@codesandbox/utils/-/utils-1.0.2.tgz",
+      "integrity": "sha512-6F+KS+/JVtgWreEy+xCL/OwxjeO5RrQNKcGTO5PfW6xo45z17TngJlmvXDHbOP8UVp+YJuUavuh4fIUTQwLz5g=="
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -5834,6 +5839,7 @@
     "packages/client": {
       "version": "0.0.0",
       "dependencies": {
+        "@codesandbox/utils": "^1.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,6 +12,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@codesandbox/utils": "^1.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -1,9 +1,13 @@
 import { useState, type ChangeEvent } from 'react';
+import { getCodeSandboxHost } from "@codesandbox/utils";
 
 type Hotel = { _id: string, chain_name: string; hotel_name: string; city: string, country: string };
 
+const codeSandboxHost = getCodeSandboxHost(3001)
+const API_URL = codeSandboxHost ? `https://${codeSandboxHost}` : 'http://localhost:3001'
+
 const fetchAndFilterHotels = async (value: string) => {
-  const hotelsData = await fetch('http://localhost:3001/hotels');
+  const hotelsData = await fetch(`${API_URL}/hotels`);
   const hotels = (await hotelsData.json()) as Hotel[];
   return hotels.filter(
     ({ chain_name, hotel_name, city, country }) =>


### PR DESCRIPTION
### Fix CodeSandbox API URL proxy
- [x] Determine which API URL to use, using the `@ codesandbox/utils` package
The util will return `undefined` if not executed on a CodeSandbox environment.

### Documentation
<img width="920" alt="Screenshot 2024-07-12 at 12 14 42" src="https://github.com/user-attachments/assets/9021c928-60de-4059-8707-ec6c8dfc4b09">

https://codesandbox.io/docs/learn/environment/preview-urls

### Preview
![Screenshot 2024-07-12 at 12 20 00](https://github.com/user-attachments/assets/34282e04-e759-4bd1-90be-1061eb800433)

https://codesandbox.io/p/github/tryhackme/full-stack-search/fix-codesandbox-api-url?file=%2Fpackages%2Fclient%2Fsrc%2Fapp.tsx%3A3%2C1&workspaceId=6e2ebbd3-2478-4d40-808c-125049c857c7